### PR TITLE
Don't pass `undefined` as parameters to `close()`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components
 output
 .psci*
+.pursuit.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ sudo: false
 node_js:
   - 5.6
 install:
-- npm install purescript bower pulp -g
+- npm install purescript bower pulp purescript-psa -g
 - bower install
 script:
-  - pulp build && pulp docs
+  - pulp build --censor-lib && pulp docs
   - bower link
-  - cd example/ && bower link purescript-websocket-simple && bower install && pulp build
+  - cd example/ && bower -q link purescript-websocket-simple && bower -q install && pulp build --censor-lib
 
 after_success:
   - >-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - 0.10
-env:
-  - PATH=$HOME/purescript:$PATH
+  - 5.6
 install:
-- TAG="v0.8.0-RC1"
-- wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
-- tar -xvf $HOME/purescript.tar.gz -C $HOME/
-- chmod a+x $HOME/purescript
-- npm install bower pulp -g
+- npm install purescript bower pulp -g
 - bower install
 script:
   - pulp build && pulp docs
@@ -19,10 +13,8 @@ script:
 after_success:
   - >-
     test $TRAVIS_TAG &&
-    psc-publish \
-      | tail -n 1 \
-      > output/documentation.json &&
-    curl -X POST http://pursuit.purescript.org/packages \
-      -d @output/documentation.json \
+    psc-publish > .pursuit.json &&
+    curl -X POST https://pursuit.purescript.org/packages \
+      -d @.pursuit.json \
       -H 'Accept: application/json' \
       -H "Authorization: token ${GITHUB_TOKEN}"

--- a/example/src/Main.purs
+++ b/example/src/Main.purs
@@ -34,7 +34,7 @@ main = do
 
     when (received == "goodbye") do
       log "onmessage: closing connection"
-      socket.close Nothing Nothing
+      socket.close
 
   socket.onclose $= \event -> do
     logAny event

--- a/src/WebSocket.js
+++ b/src/WebSocket.js
@@ -37,13 +37,17 @@ exports.newWebSocketImpl = function(url, protocols) {
            , getReadyState: getSocketProp("readyState")
            , getUrl: getSocketProp("url")
            , closeImpl:
-              function(mCode) {
-                return function(mReason) {
-                  return function() {
-                    socket.close(mCode.value0, mReason.value0);
-                    return {};
+              function(params) {
+                return function() {
+                  if (params == null) {
+                    socket.close();
+                  } else if (params.reason == null) {
+                    socket.close(params.code);
+                  } else {
+                    socket.close(params.code, params.reason);
                   }
-                }
+                  return {}
+                } 
               }
            , sendImpl:
               function(message) {

--- a/src/WebSocket.purs
+++ b/src/WebSocket.purs
@@ -40,6 +40,7 @@ import Unsafe.Coerce (unsafeCoerce)
 import Data.Either (Either(..))
 import Data.Foreign (toForeign, unsafeFromForeign)
 import Data.Foreign.Index (prop)
+import Data.Nullable (toNullable, Nullable())
 
 foreign import specViolation :: forall a. String -> a
 
@@ -63,20 +64,34 @@ runMessageEvent event = case prop "data" (toForeign event) of
                       Left _  -> specViolation "'data' missing from MessageEvent"
 
 type ConnectionImpl =
-  { setBinaryType     :: forall eff. String -> Eff (ws :: WEBSOCKET | eff) Unit
-  , getBinaryType     :: forall eff. Eff (ws :: WEBSOCKET | eff) String
-  , getBufferedAmount :: forall eff. Eff (ws :: WEBSOCKET | eff) BufferedAmount
-  , setOnclose        :: forall eff handlerEff. EventListener handlerEff -> Eff (ws :: WEBSOCKET | eff) Unit
-  , setOnerror        :: forall eff handlerEff. EventListener handlerEff -> Eff (ws :: WEBSOCKET | eff) Unit
-  , setOnmessage      :: forall eff handlerEff. EventListener handlerEff -> Eff (ws :: WEBSOCKET | eff) Unit
-  , setOnopen         :: forall eff handlerEff. EventListener handlerEff -> Eff (ws :: WEBSOCKET | eff) Unit
-  , setProtocol       :: forall eff. Protocol -> Eff (ws :: WEBSOCKET | eff) Unit
-  , getProtocol       :: forall eff. Eff (ws :: WEBSOCKET | eff) Protocol
-  , getReadyState     :: forall eff. Eff (ws :: WEBSOCKET | eff) Int
-  , getUrl            :: forall eff. Eff (ws :: WEBSOCKET | eff) URL
-  , closeImpl         :: forall eff. Maybe Code -> Maybe Reason -> Eff (ws :: WEBSOCKET | eff) Unit
-  , sendImpl          :: forall eff. Message -> Eff (ws :: WEBSOCKET | eff) Unit
-  , getSocket         :: forall eff. Eff (ws :: WEBSOCKET | eff) WebSocket
+  { setBinaryType
+      :: forall eff. String -> Eff (ws :: WEBSOCKET | eff) Unit
+  , getBinaryType
+      :: forall eff. Eff (ws :: WEBSOCKET | eff) String
+  , getBufferedAmount
+      :: forall eff. Eff (ws :: WEBSOCKET | eff) BufferedAmount
+  , setOnclose
+      :: forall eff handlerEff. EventListener handlerEff -> Eff (ws :: WEBSOCKET | eff) Unit
+  , setOnerror
+      :: forall eff handlerEff. EventListener handlerEff -> Eff (ws :: WEBSOCKET | eff) Unit
+  , setOnmessage
+      :: forall eff handlerEff. EventListener handlerEff -> Eff (ws :: WEBSOCKET | eff) Unit
+  , setOnopen
+      :: forall eff handlerEff. EventListener handlerEff -> Eff (ws :: WEBSOCKET | eff) Unit
+  , setProtocol
+      :: forall eff. Protocol -> Eff (ws :: WEBSOCKET | eff) Unit
+  , getProtocol
+      :: forall eff. Eff (ws :: WEBSOCKET | eff) Protocol
+  , getReadyState
+      :: forall eff. Eff (ws :: WEBSOCKET | eff) Int
+  , getUrl
+      :: forall eff. Eff (ws :: WEBSOCKET | eff) URL
+  , closeImpl
+      :: forall eff. Nullable { code :: Code, reason :: Nullable Reason } -> Eff (ws :: WEBSOCKET | eff) Unit
+  , sendImpl
+      :: forall eff. Message -> Eff (ws :: WEBSOCKET | eff) Unit
+  , getSocket
+      :: forall eff. Eff (ws :: WEBSOCKET | eff) WebSocket
   }
 
 coerceEvent :: forall a. Event -> a
@@ -93,7 +108,8 @@ enhanceConnection c = Connection
   , protocol: makeVar c.getProtocol c.setProtocol
   , readyState: unsafeReadyState <$> makeGettableVar c.getReadyState
   , url: makeGettableVar c.getUrl
-  , close: c.closeImpl
+  , close: c.closeImpl (toNullable Nothing)
+  , close': \code reason -> c.closeImpl (toNullable (Just { code, reason: toNullable reason }))
   , send: c.sendImpl
   , socket: makeGettableVar c.getSocket
   }
@@ -137,7 +153,8 @@ newtype Connection = Connection
   , protocol       :: forall eff. Var (ws :: WEBSOCKET | eff) Protocol
   , readyState     :: forall eff. GettableVar (ws :: WEBSOCKET | eff) ReadyState
   , url            :: forall eff. GettableVar (ws :: WEBSOCKET | eff) URL
-  , close          :: forall eff. Maybe Code -> Maybe Reason -> Eff (ws :: WEBSOCKET | eff) Unit
+  , close          :: forall eff. Eff (ws :: WEBSOCKET | eff) Unit
+  , close'         :: forall eff. Code -> Maybe Reason -> Eff (ws :: WEBSOCKET | eff) Unit
   , send           :: forall eff. Message -> Eff (ws :: WEBSOCKET | eff) Unit
   , socket         :: forall eff. GettableVar (ws :: WEBSOCKET | eff) WebSocket
   }
@@ -216,9 +233,10 @@ fromEnumReadyState Open       = 1
 fromEnumReadyState Closing    = 2
 fromEnumReadyState Closed     = 3
 
--- | A numeric value indicating the status code explaining why the connection is being closed.
--- | See [the list of status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).
-newtype Code = Code Int
+-- | Should be either equal to 1000 (indicating normal closure) or in the range
+-- | of 3000-4999.
+newtype Code
+  = Code Int
 
 runCode :: Code -> Int
 runCode (Code a) = a


### PR DESCRIPTION
Fix #8.
- `Connection.close` always calls `close()`
- `Connection.close' { code: Code 1000, reason: Nothing } calls
  `close(1000)`
- `Connection.close' { code: Code 1000, reason: Just (Reason "foo") }`
  calls `close(1000, "foo")`.
- Docstring for `Code` is updated
