### PR TITLE
bump dependencies for purescript-0.10.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 sudo: false
 node_js:
-  - 5.6
+  - node
 install:
-- npm install purescript@0.9.3 bower pulp purescript-psa -g
+- npm install purescript@0.10.2 bower pulp purescript-psa -g
 - bower install
 script:
   - pulp build --censor-lib && pulp docs

--- a/bower.json
+++ b/bower.json
@@ -23,13 +23,13 @@
     "purescript"
   ],
   "dependencies": {
-    "purescript-generics": "^1.0.0",
-    "purescript-eff": "^1.0.0",
-    "purescript-var": "^0.2.0",
-    "purescript-dom": "^2.0.0",
-    "purescript-exceptions": "^1.0.0"
+    "purescript-dom": "^3.1.0",
+    "purescript-eff": "^2.0.0",
+    "purescript-exceptions": "^2.0.0",
+    "purescript-generics": "^3.1.0",
+    "purescript-var": "^1.0.0"
   },
   "devDependencies": {
-    "purescript-console": "~1.0.0"
+    "purescript-console": "~2.0.0"
   }
 }

--- a/example/bower.json
+++ b/example/bower.json
@@ -11,8 +11,8 @@
     "output"
   ],
   "dependencies": {
-    "purescript-console": "^1.0.0",
-    "purescript-debug": "^1.0.0",
+    "purescript-console": "^2.0.0",
+    "purescript-debug": "^2.0.0",
     "purescript-websocket-simple": "*"
   }
 }

--- a/src/WebSocket.purs
+++ b/src/WebSocket.purs
@@ -25,6 +25,7 @@ module WebSocket
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Eff.Var (Var, GettableVar, SettableVar, makeVar, makeGettableVar, makeSettableVar)
+import Control.Monad.Except (runExcept)
 import DOM.Event.EventTarget (eventListener, EventListener)
 import DOM.Event.Types (Event)
 import DOM.Websocket.Event.Types (CloseEvent, MessageEvent)
@@ -58,7 +59,7 @@ foreign import newWebSocketImpl :: forall eff. Fn2 URL
                                                    (Eff (ws :: WEBSOCKET, err :: EXCEPTION | eff) ConnectionImpl)
 
 runMessageEvent :: MessageEvent -> Message
-runMessageEvent event = case prop "data" (toForeign event) of
+runMessageEvent event = case runExcept (prop "data" (toForeign event)) of
                       Right x -> unsafeFromForeign x
                       Left _  -> specViolation "'data' missing from MessageEvent"
 


### PR DESCRIPTION
* updates the dependencies (using the latest [purescript-var](https://pursuit.purescript.org/packages/purescript-var/1.0.0) too)
* utilizes the latest `Foreign` error monad signature